### PR TITLE
import sys for sys.exit()

### DIFF
--- a/libs/opsworks.py
+++ b/libs/opsworks.py
@@ -5,6 +5,7 @@ Opsworks functions for WeirdAAL
 import boto3
 import botocore
 import pprint
+import sys
 
 pp = pprint.PrettyPrinter(indent=5, width=80)
 

--- a/libs/rds.py
+++ b/libs/rds.py
@@ -5,6 +5,7 @@ RDS functions for WeirdAAL
 import boto3
 import botocore
 import pprint
+import sys
 
 pp = pprint.PrettyPrinter(indent=5, width=80)
 

--- a/libs/s3.py
+++ b/libs/s3.py
@@ -6,6 +6,7 @@ import boto3
 import botocore
 import os
 import pprint
+import sys
 
 pp = pprint.PrettyPrinter(indent=5, width=80)
 

--- a/libs/ses.py
+++ b/libs/ses.py
@@ -5,6 +5,7 @@ SES functions for WeirdAAL
 import boto3
 import botocore
 import pprint
+import sys
 
 pp = pprint.PrettyPrinter(indent=5, width=80)
 

--- a/libs/sns.py
+++ b/libs/sns.py
@@ -4,6 +4,7 @@ utilities for working with SNS
 
 import boto3
 import botocore
+import sys
 
 regions = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2']
 

--- a/libs/sqs.py
+++ b/libs/sqs.py
@@ -5,6 +5,7 @@ SQS functions for WeirdAAL
 import boto3
 import botocore
 import pprint
+import sys
 
 pp = pprint.PrettyPrinter(indent=5, width=80)
 


### PR DESCRIPTION
Each of these files calls __sys.exit()__ but does not __import sys__ which may result in __NameError__ being raised instead of __sys.exit()__ being called.

This PR should resolve most but not all of the undefined names issues found in flake8 testing of https://github.com/carnal0wnage/weirdAAL on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./libs/aws_lambda.py:135:86: F821 undefined name 'region'
            print("[-] GetAccountSettings allowed for {} but no results [-]" .format(region))
                                                                                     ^
./libs/opsworks.py:49:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/opsworks.py:86:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/rds.py:49:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/s3.py:102:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:160:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:184:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:211:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:240:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:264:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:288:54: F821 undefined name 'file'
            print("{} object does not exist.".format(file))
                                                     ^
./libs/s3.py:290:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/s3.py:316:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/ses.py:48:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/ses.py:85:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/ses.py:122:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/sns.py:29:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/sns.py:50:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/sns.py:69:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/sns.py:87:13: F821 undefined name 'sys'
            sys.exit("The AWS KEY IS INVALID. Exiting")
            ^
./libs/sqs.py:42:13: F821 undefined name 'sys'
            sys.exit("{} : The AWS KEY IS INVALID. Exiting" .format(AWS_ACCESS_KEY_ID))
            ^
./libs/sts.py:36:69: F821 undefined name 'region'
            print("[-] Cant connect to the {} endpoint [-]" .format(region))
                                                                    ^
./libs/sts.py:63:69: F821 undefined name 'region'
            print("[-] Cant connect to the {} endpoint [-]" .format(region))
                                                                    ^
23    F821 undefined name 'region'
23
```