### PR TITLE
Typo in variable name: file --> source_file

### DIFF
--- a/libs/s3.py
+++ b/libs/s3.py
@@ -286,7 +286,7 @@ def s3_upload_file(bucket, source_file, dest_file):
         print("[-] {} not found [-]".format(source_file))
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == "404":
-            print("{} object does not exist.".format(file))
+            print("{} object does not exist.".format(source_file))
         elif e.response['Error']['Code'] == 'InvalidClientTokenId':
             sys.exit("The AWS KEY IS INVALID. Exiting")
         elif e.response['Error']['Code'] == 'NotSignedUp':


### PR DESCRIPTION
Should solve one undefined name in flake8 testing of https://github.com/carnal0wnage/weirdAAL on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./libs/aws_lambda.py:135:86: F821 undefined name 'region'
            print("[-] GetAccountSettings allowed for {} but no results [-]" .format(region))
                                                                                     ^
./libs/s3.py:289:54: F821 undefined name 'file'
            print("{} object does not exist.".format(file))
                                                     ^
2     F821 undefined name 'region'
2
```