### PR TITLE
Resolve undefined name 'region'.  Use AWS_ACCESS_KEY_ID

### DIFF
--- a/libs/aws_lambda.py
+++ b/libs/aws_lambda.py
@@ -132,7 +132,7 @@ def lambda_get_account_settings():
         if response.get('AccountLimit') is None:
             print("{} likely does not have Lambda permissions\n" .format(AWS_ACCESS_KEY_ID))
         elif len(response['AccountLimit']) <= 0:
-            print("[-] GetAccountSettings allowed for {} but no results [-]" .format(region))
+            print("[-] GetAccountSettings allowed for {} but no results [-]" .format(AWS_ACCESS_KEY_ID))
         else:
             print("AccountLimit:")
             pp.pprint(response['AccountLimit'])


### PR DESCRIPTION
__region__ is an _undefined name_ in this context so this PR recommends using __AWS_ACCESS_KEY_ID__ instead.

flake8 testing of https://github.com/carnal0wnage/weirdAAL on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./libs/aws_lambda.py:135:86: F821 undefined name 'region'
            print("[-] GetAccountSettings allowed for {} but no results [-]" .format(region))
                                                                                     ^
./libs/s3.py:289:54: F821 undefined name 'file'
            print("{} object does not exist.".format(file))
                                                     ^
2     F821 undefined name 'region'
2
```