### PR TITLE
Normalized module names when listing

### DIFF
--- a/weirdAAL.py
+++ b/weirdAAL.py
@@ -110,6 +110,7 @@ def make_tabulate_rows(hash, cloud_provider):
         for item in hash[key]:
             for (k,v) in item.items():
                 normalized_comment = normalize_comments(v)
+                k = re.sub("module_", "", k)
                 entire_contents.append([cloud_provider, key, k, normalized_comment])
 
     return entire_contents


### PR DESCRIPTION
Doing slide deck prep it dawned on me the module listing shows it with the `module_` piece prepended (which, you wouldn't enter when doing a `-m` option). So instead of confusing people, I'm removing the `module_` piece from the printout so they just get the module name as they would enter it into the cli.