### PR TITLE
Use Pipenv instead of Pip + Virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,9 @@ ENV/
 
 # mkdocs documentation
 /site
+
+# intellij
+.idea
+
+# vscode
+.vscode

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,19 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+boto3 = "*"
+botocore = "*"
+docutils = "*"
+jmespath = "*"
+python-dateutil = "*"
+s3transfer = "*"
+six = "*"
+tabulate = "*"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -7,13 +7,8 @@ verify_ssl = true
 
 [packages]
 boto3 = "*"
-botocore = "*"
-docutils = "*"
-jmespath = "*"
-python-dateutil = "*"
-s3transfer = "*"
-six = "*"
 tabulate = "*"
+botocore = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,93 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "97005a566c044462bbc23824c21a6cd99eacba0faff1e30e9d3cd04dc12e82ad"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "boto3": {
+            "hashes": [
+                "sha256:1a0cc76f91f1c46804da4c6486ab4b806a765eaa3470a2d6c1cc6c1a0f466057",
+                "sha256:1cd2f629a1340d217e8cc746e9241fe8d51cb4e654050921b2cdb22498978b4c"
+            ],
+            "index": "pypi",
+            "version": "==1.9.173"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:18903b5dabfc081ed7d00aac5365b46878f39ca4f4f5c91537510583697e4ae2",
+                "sha256:1b7adcd080fcb010831cbbbaa2e6de26b79401a021ad5462678a36711bf442ae"
+            ],
+            "index": "pypi",
+            "version": "==1.12.173"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "index": "pypi",
+            "version": "==0.14"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+            ],
+            "index": "pypi",
+            "version": "==0.9.4"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "index": "pypi",
+            "version": "==2.8.0"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
+                "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
+            ],
+            "index": "pypi",
+            "version": "==0.2.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "index": "pypi",
+            "version": "==1.12.0"
+        },
+        "tabulate": {
+            "hashes": [
+                "sha256:8af07a39377cee1103a5c8b3330a421c2d99b9141e9cc5ddd2e3263fea416943"
+            ],
+            "index": "pypi",
+            "version": "==0.8.3"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "markers": "python_version >= '3.4'",
+            "version": "==1.25.3"
+        }
+    },
+    "develop": {}
+}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "97005a566c044462bbc23824c21a6cd99eacba0faff1e30e9d3cd04dc12e82ad"
+            "sha256": "a15488be2834c3c080e943fde08bd928a66d108cc5b6d45189d09f931f1d92f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,7 +38,6 @@
                 "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
                 "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
             ],
-            "index": "pypi",
             "version": "==0.14"
         },
         "jmespath": {
@@ -46,7 +45,6 @@
                 "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
                 "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
             ],
-            "index": "pypi",
             "version": "==0.9.4"
         },
         "python-dateutil": {
@@ -54,7 +52,7 @@
                 "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
                 "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.7'",
             "version": "==2.8.0"
         },
         "s3transfer": {
@@ -62,7 +60,6 @@
                 "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
                 "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
             ],
-            "index": "pypi",
             "version": "==0.2.1"
         },
         "six": {
@@ -70,7 +67,6 @@
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "index": "pypi",
             "version": "==1.12.0"
         },
         "tabulate": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-boto3==1.7.4
-botocore==1.10.4
-docutils==0.14
-jmespath==0.9.3
-python-dateutil==2.6.1
-s3transfer==0.1.11
-six==1.11.0
-virtualenv==15.1.0
-tabulate==0.8.2


### PR DESCRIPTION
Versions locked by Pipfile.lock, simplifies the setup in the Wiki. Upgrade packages in future by running `pipenv update`. I don't have permission to update, but the Setup page of the wiki should now show:


setup infoz:
```bash
git clone https://github.com/carnal0wnage/weirdAAL.git
cd weirdAAL

pip3 install pipenv (if required)

pipenv install
pipenv shell
```

OSX Setup:
```bash
$ brew install python
$ pip3 install pipenv
$ pipenv install
$ pipenv shell
```

Then, all references to `python3` can just be `python` as python 3 will be the only available interpreter inside the pipenv shell.

Dependency graph:
```bash
➜ pipenv graph           
boto3==1.9.173
  - botocore [required: >=1.12.173,<1.13.0, installed: 1.12.173]
    - docutils [required: >=0.10, installed: 0.14]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
    - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.0]
      - six [required: >=1.5, installed: 1.12.0]
    - urllib3 [required: >=1.20,<1.26, installed: 1.25.3]
  - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
  - s3transfer [required: >=0.2.0,<0.3.0, installed: 0.2.1]
    - botocore [required: >=1.12.36,<2.0.0, installed: 1.12.173]
      - docutils [required: >=0.10, installed: 0.14]
      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.0]
        - six [required: >=1.5, installed: 1.12.0]
      - urllib3 [required: >=1.20,<1.26, installed: 1.25.3]
tabulate==0.8.3
```